### PR TITLE
Feat/i18n

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ Create a `.env` file at the root of the project with the following content:
 ```
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8080/api
 ```
+
+### i18n
+
+We use [i18next](https://www.i18next.com/) and [react-18next](https://react.i18next.com/) to handle translations in this project
+
+All translation files are stored inside the `src/i18n` folder.
+Each file inside a language folder corresponds to a subfolder of the `app`, `components`, `errors`... folders.
+Each file is mapped by i18next as a **namespace**.

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "dayjs": "1.9.7",
     "framer-motion": "3.0.0",
     "history": "5.0.0",
+    "i18next": "19.8.4",
+    "i18next-http-backend": "1.0.21",
     "next": "10.0.3",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-error-boundary": "3.1.0",
+    "react-i18next": "11.8.4",
     "react-icons": "4.1.0",
     "react-query": "3.3.2",
     "react-router-dom": "5.2.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "framer-motion": "3.0.0",
     "history": "5.0.0",
     "i18next": "19.8.4",
-    "i18next-http-backend": "1.0.21",
+    "i18next-browser-languagedetector": "6.0.1",
     "next": "10.0.3",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,3 +1,0 @@
-{
-  "appTitle": "Start UI"
-}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,3 @@
+{
+  "appTitle": "Start UI"
+}

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,3 +1,0 @@
-{
-  "appTitle": "Start UI"
-}

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,0 +1,3 @@
+{
+  "appTitle": "Start UI"
+}

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { AuthProvider } from '@/app/auth/AuthContext';
 import '@/config/axios';
 import '@/config/dayjs';
+import '@/config/i18next';
 import theme from '@/theme';
 
 const queryClient = new QueryClient();

--- a/src/app/account/PageAccount.tsx
+++ b/src/app/account/PageAccount.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { Heading } from '@chakra-ui/react';
 
@@ -6,11 +7,12 @@ import { useAccount } from '@/app/account/service';
 import { Page, PageBody, PageHeader } from '@/components';
 
 export const PageAccount = () => {
+  const { t } = useTranslation();
   const { account } = useAccount();
   return (
     <Page>
       <PageHeader>
-        <Heading size="md">Account</Heading>
+        <Heading size="md">{t('account:title')}</Heading>
       </PageHeader>
       <PageBody>
         <pre>{JSON.stringify(account, null, 2)}</pre>

--- a/src/app/account/PageActivate.tsx
+++ b/src/app/account/PageActivate.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { Box, Spinner } from '@chakra-ui/react';
 
@@ -6,6 +7,7 @@ import { useActivateAccount } from '@/app/account/service';
 import { useSearchParams } from '@/app/router';
 
 export const PageActivate = () => {
+  const { t } = useTranslation();
   const {
     mutate: activateAccount,
     isError,
@@ -21,8 +23,9 @@ export const PageActivate = () => {
   return (
     <Box p="4" maxW="20rem" m="auto">
       {isLoading && <Spinner size="sm" mr="2" />}
-      Account Activation {isSuccess && 'Success'}
-      {isError && 'Error'}
+      {isLoading && t('account:accountActivation.accountActivationPending')}
+      {isSuccess && t('account:accountActivation.accountActivationSuccess')}
+      {isError && t('account:accountActivation.accountActivationError')}
     </Box>
   );
 };

--- a/src/app/account/PageRegister.tsx
+++ b/src/app/account/PageRegister.tsx
@@ -20,11 +20,13 @@ import {
   isPattern,
 } from '@formiz/validations';
 import { Link as RouterLink } from 'react-router-dom';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { useCreateAccount } from '@/app/account/service';
 import { FieldInput, useToastError } from '@/components';
 
 export const PageRegister = () => {
+  const { t } = useTranslation();
   const form = useForm();
   const toastError = useToastError();
   const [accountEmail, setAccountEmail] = useState('');
@@ -37,16 +39,16 @@ export const PageRegister = () => {
       const { errorKey, title } = error?.response?.data || {};
 
       toastError({
-        title: 'Registration failed',
+        title: t('account:register.messages.registrationFailed'),
         description: title,
       });
 
       if (errorKey === 'userexists') {
-        form.invalidateFields({ login: 'Login already used' });
+        form.invalidateFields({ login: t('account:register.form.login.userexists') });
       }
 
       if (errorKey === 'emailexists') {
-        form.invalidateFields({ email: 'Email already used' });
+        form.invalidateFields({ email: t('account:register.form.email.emailexists') });
       }
     },
   });
@@ -68,17 +70,23 @@ export const PageRegister = () => {
           >
             <Box fontSize="3rem">🎉</Box>
             <AlertTitle mt={4} mb={1} fontSize="lg">
-              Account created with success!
+              {t('account:register.messages.accountCreatedSuccess.title')}
             </AlertTitle>
             <AlertDescription>
-              Please check your email <strong>{accountEmail}</strong> inbox to
-              activate your account.
+              <Trans
+                t={t}
+                i18nKey="account:register.messages.accountCreatedSuccess.description"
+                tOptions={{ accountEmail }}
+              >
+                Please check your email <strong>{accountEmail}</strong> inbox to
+                activate your account.
+              </Trans>
             </AlertDescription>
           </Alert>
           <Center mt="8">
             <Button as={RouterLink} to="/login" variant="link">
               <Box as="strong" color="brand.500" ml="2">
-                Go to Login
+                {t('account:register.actions.goToLogin')}
               </Box>
             </Button>
           </Center>
@@ -95,61 +103,61 @@ export const PageRegister = () => {
         onValidSubmit={createUser}
         connect={form}
       >
-        <Heading my="4">Register</Heading>
+        <Heading my="4">{t('account:register.title')}</Heading>
         <Stack spacing="4">
           <FieldInput
             name="login"
-            label="Username"
-            required="Username is required"
+            label={t('account:register.form.login.label') as string}
+            required={t('account:register.form.login.required') as string}
             validations={[
               {
                 rule: isMinLength(2),
-                message: 'Username too short (min. 2 characters)',
+                message: t('account:register.form.login.isMinLength', { count: 2 }),
               },
               {
                 rule: isMaxLength(50),
-                message: 'Username too long (max. 50 characters)',
+                message: t('account:register.form.login.isMaxLength', { count: 50 }),
               },
               {
                 rule: isPattern(
                   '^[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$|^[_.@A-Za-z0-9-]+$'
                 ),
-                message: "Username is invalid, don't use special characters",
+                message: t('account:register.form.login.isPattern'),
               },
             ]}
           />
           <FieldInput
             name="email"
-            label="Email"
-            required="Email is required"
+            label={t('account:register.form.email.label') as string}
+            required={t('account:register.form.email.required') as string}
             validations={[
               {
                 rule: isMinLength(5),
-                message: 'Email too short (min. 5 characters)',
+                message: t('account:register.form.email.isMinLength', { count: 5 }),
               },
               {
                 rule: isMaxLength(254),
-                message: 'Email too long (max. 254 characters)',
+                message: t('account:register.form.email.isMaxLength', { count: 254 }),
               },
               {
                 rule: isEmail(),
-                message: 'Email is invalid',
+                message: t('account:register.form.email.isEmail'),
               },
             ]}
           />
           <FieldInput
             name="password"
             type="password"
-            label="Password"
-            required="Password is required"
+            label={t('account:register.form.password.label') as string}
+            required={t('account:register.form.password.required') as string}
             validations={[
               {
                 rule: isMinLength(4),
-                message: 'Password too short (min. 4 characters)',
+                message: t('account:register.form.password.isMinLength', { count: 4 }),
               },
               {
                 rule: isMaxLength(50),
-                message: 'Password too long (max. 50 characters)',
+                message: t('account:register.form.password.isMaxLength', { count: 50 }),
               },
             ]}
           />
@@ -161,15 +169,15 @@ export const PageRegister = () => {
               colorScheme="brand"
               ml="auto"
             >
-              Create Account
+              {t('account:register.actions.createAccount')}
             </Button>
           </Flex>
         </Stack>
         <Center mt="8">
           <Button as={RouterLink} to="/login" variant="link">
-            Already have an account?{' '}
+            {t('account:register.actions.alreadyHaveAnAccount')}{' '}
             <Box as="strong" color="brand.500" ml="2">
-              Login
+              {t('account:register.actions.login')}
             </Box>
           </Button>
         </Center>

--- a/src/app/admin/users/PageUser.tsx
+++ b/src/app/admin/users/PageUser.tsx
@@ -8,8 +8,10 @@ import { useUser } from '@/app/admin/users/service';
 import { Page, PageBody, PageFooter, PageHeader } from '@/components';
 
 import { UserStatus } from './UserStatus';
+import { useTranslation } from 'react-i18next';
 
 export const PageUser = () => {
+  const { t } = useTranslation();
   const { login } = useParams();
   const history = useHistory();
   const { user } = useUser(login);
@@ -26,7 +28,7 @@ export const PageUser = () => {
             />
           </Box>
           <Box flex="1">
-            <Heading size="sm">User {user?.login}</Heading>
+            <Heading size="sm">{t('admin:user')} {user?.login}</Heading>
             <Text fontSize="sm" color="gray.600">
               {user?.email}
             </Text>

--- a/src/app/admin/users/PageUser.tsx
+++ b/src/app/admin/users/PageUser.tsx
@@ -28,7 +28,7 @@ export const PageUser = () => {
             />
           </Box>
           <Box flex="1">
-            <Heading size="sm">{t('admin:user')} {user?.login}</Heading>
+            <Heading size="sm">{t('admin:users.user')} {user?.login}</Heading>
             <Text fontSize="sm" color="gray.600">
               {user?.email}
             </Text>

--- a/src/app/admin/users/PageUsers.tsx
+++ b/src/app/admin/users/PageUsers.tsx
@@ -64,26 +64,26 @@ const UserActions = ({ user, ...rest }) => {
     onSuccess: ({ activated, login }) => {
       if (activated) {
         toastSuccess({
-          title: t('admin:messages.accountActivated.title'),
-          description: t('admin:messages.accountActivated.description', { login }),
+          title: t('admin:users.messages.accountActivated.title'),
+          description: t('admin:users.messages.accountActivated.description', { login }),
         });
       } else {
         toastSuccess({
-          title: t('admin:messages.accountDeactivated.title'),
-          description: t('admin:messages.accountDeactivated.description', { login }),
+          title: t('admin:users.messages.accountDeactivated.title'),
+          description: t('admin:users.messages.accountDeactivated.description', { login }),
         });
       }
     },
     onError: (_, __, { activated, login }) => {
       if (activated) {
         toastError({
-          title: t('admin:messages.accountActivationFailed.title'),
-          description: t('admin:messages.accountActivationFailed.description', { login }),
+          title: t('admin:users.messages.accountActivationFailed.title'),
+          description: t('admin:users.messages.accountActivationFailed.description', { login }),
         });
       } else {
         toastError({
-          title: t('admin:messages.accountDeactivationFailed.title'),
-          description: t('admin:messages.accountDeactivationFailed.description', { login }),
+          title: t('admin:users.messages.accountDeactivationFailed.title'),
+          description: t('admin:users.messages.accountDeactivationFailed.description', { login }),
         });
       }
     },
@@ -102,28 +102,28 @@ const UserActions = ({ user, ...rest }) => {
             to={`${path}${user.login}`}
             icon={<Icon as={FiEdit} fontSize="lg" color="gray.400" />}
           >
-            {t('admin:actions.edit')}
+            {t('admin:users.actions.edit')}
           </MenuItem>
           {user.activated ? (
             <MenuItem
               onClick={deactivateUser}
               icon={<Icon as={FiXCircle} fontSize="lg" color="gray.400" />}
             >
-              {t('admin:actions.deactivateAccount')}
+              {t('admin:users.actions.deactivateAccount')}
             </MenuItem>
           ) : (
             <MenuItem
               onClick={activateUser}
               icon={<Icon as={FiCheckCircle} fontSize="lg" color="gray.400" />}
             >
-              {t('admin:actions.activateAccount')}
+              {t('admin:users.actions.activateAccount')}
             </MenuItem>
           )}
           <MenuDivider />
           <MenuItem
             icon={<Icon as={FiTrash2} fontSize="lg" color="gray.400" />}
           >
-            {t('admin:actions.delete')}
+            {t('admin:users.actions.delete')}
           </MenuItem>
         </MenuList>
       </Portal>
@@ -146,7 +146,7 @@ export const PageUsers = () => {
       <PageHeader>
         <HStack>
           <Box flex="1">
-            <Heading size="md">{t('admin:userManagement')}</Heading>
+            <Heading size="md">{t('admin:users.userManagement')}</Heading>
           </Box>
           <Box>
             <Button
@@ -156,11 +156,11 @@ export const PageUsers = () => {
               colorScheme="brand"
               leftIcon={<FiPlus />}
             >
-              {t('admin:actions.createUser')}
+              {t('admin:users.actions.createUser')}
             </Button>
             <IconButton
               display={{ base: 'flex', sm: 'none' }}
-              aria-label={t('admin:actions.createUser')}
+              aria-label={t('admin:users.actions.createUser')}
               as={Link}
               to={`${path}create`}
               size="sm"
@@ -174,32 +174,32 @@ export const PageUsers = () => {
         <DataList>
           <DataListHeader isVisible={{ base: false, md: true }}>
             <DataListCell colName="login" colWidth="2">
-              {t('admin:loginEmail')}
+              {t('admin:users.loginEmail')}
             </DataListCell>
             <DataListCell
               colName="id"
               colWidth="4rem"
               isVisible={{ base: false, lg: true }}
             >
-              {t('admin:id')}
+              {t('admin:users.id')}
             </DataListCell>
             <DataListCell
               colName="authorities"
               isVisible={{ base: false, lg: true }}
             >
-              {t('admin:authorities')}
+              {t('admin:users.authorities')}
             </DataListCell>
             <DataListCell
               colName="created"
               isVisible={{ base: false, lg: true }}
             >
-              {t('admin:createdBy')}
+              {t('admin:users.createdBy')}
             </DataListCell>
             <DataListCell
               colName="lastModified"
               isVisible={{ base: false, md: true }}
             >
-              {t('admin:modifiedBy')}
+              {t('admin:users.modifiedBy')}
             </DataListCell>
             <DataListCell
               colName="status"
@@ -207,7 +207,7 @@ export const PageUsers = () => {
               align="center"
             >
               <Box as="span" d={{ base: 'none', md: 'block' }}>
-                {t('admin:status')}
+                {t('admin:users.status')}
               </Box>
             </DataListCell>
             <DataListCell colName="actions" colWidth="4rem" align="flex-end" />

--- a/src/app/admin/users/PageUsers.tsx
+++ b/src/app/admin/users/PageUsers.tsx
@@ -28,6 +28,7 @@ import {
   FiPlus,
 } from 'react-icons/fi';
 import { Link, useRouteMatch } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 import { UserStatus } from '@/app/admin/users/UserStatus';
 import { useUserList, useUserUpdate } from '@/app/admin/users/service';
@@ -55,6 +56,7 @@ import {
 } from '@/components';
 
 const UserActions = ({ user, ...rest }) => {
+  const { t } = useTranslation();
   const { path } = useRouteMatch();
   const toastSuccess = useToastSuccess();
   const toastError = useToastError();
@@ -62,26 +64,26 @@ const UserActions = ({ user, ...rest }) => {
     onSuccess: ({ activated, login }) => {
       if (activated) {
         toastSuccess({
-          title: 'Account Activated',
-          description: `Account "${login}" activated with success`,
+          title: t('admin:messages.accountActivated.title'),
+          description: t('admin:messages.accountActivated.description', { login }),
         });
       } else {
         toastSuccess({
-          title: 'Account Deactivated',
-          description: `Account "${login}" deactivated with success`,
+          title: t('admin:messages.accountDeactivated.title'),
+          description: t('admin:messages.accountDeactivated.description', { login }),
         });
       }
     },
     onError: (_, __, { activated, login }) => {
       if (activated) {
         toastError({
-          title: 'Activation Failed',
-          description: `Fail to activate "${login}" account`,
+          title: t('admin:messages.accountActivationFailed.title'),
+          description: t('admin:messages.accountActivationFailed.description', { login }),
         });
       } else {
         toastError({
-          title: 'Deactivation Failed',
-          description: `Fail to deactivate "${login}" account`,
+          title: t('admin:messages.accountDeactivationFailed.title'),
+          description: t('admin:messages.accountDeactivationFailed.description', { login }),
         });
       }
     },
@@ -100,28 +102,28 @@ const UserActions = ({ user, ...rest }) => {
             to={`${path}${user.login}`}
             icon={<Icon as={FiEdit} fontSize="lg" color="gray.400" />}
           >
-            Edit
+            {t('admin:actions.edit')}
           </MenuItem>
           {user.activated ? (
             <MenuItem
               onClick={deactivateUser}
               icon={<Icon as={FiXCircle} fontSize="lg" color="gray.400" />}
             >
-              Deactivate Account
+              {t('admin:actions.deactivateAccount')}
             </MenuItem>
           ) : (
             <MenuItem
               onClick={activateUser}
               icon={<Icon as={FiCheckCircle} fontSize="lg" color="gray.400" />}
             >
-              Activate Account
+              {t('admin:actions.activateAccount')}
             </MenuItem>
           )}
           <MenuDivider />
           <MenuItem
             icon={<Icon as={FiTrash2} fontSize="lg" color="gray.400" />}
           >
-            Delete
+            {t('admin:actions.delete')}
           </MenuItem>
         </MenuList>
       </Portal>
@@ -130,6 +132,7 @@ const UserActions = ({ user, ...rest }) => {
 };
 
 export const PageUsers = () => {
+  const { t } = useTranslation();
   const { path } = useRouteMatch();
   const { page, setPage } = usePaginationFromUrl();
   const pageSize = 2;
@@ -143,7 +146,7 @@ export const PageUsers = () => {
       <PageHeader>
         <HStack>
           <Box flex="1">
-            <Heading size="md">User Management</Heading>
+            <Heading size="md">{t('admin:userManagement')}</Heading>
           </Box>
           <Box>
             <Button
@@ -153,11 +156,11 @@ export const PageUsers = () => {
               colorScheme="brand"
               leftIcon={<FiPlus />}
             >
-              Create User
+              {t('admin:actions.createUser')}
             </Button>
             <IconButton
               display={{ base: 'flex', sm: 'none' }}
-              aria-label="Create User"
+              aria-label={t('admin:actions.createUser')}
               as={Link}
               to={`${path}create`}
               size="sm"
@@ -171,32 +174,32 @@ export const PageUsers = () => {
         <DataList>
           <DataListHeader isVisible={{ base: false, md: true }}>
             <DataListCell colName="login" colWidth="2">
-              Login / Email
+              {t('admin:loginEmail')}
             </DataListCell>
             <DataListCell
               colName="id"
               colWidth="4rem"
               isVisible={{ base: false, lg: true }}
             >
-              ID
+              {t('admin:id')}
             </DataListCell>
             <DataListCell
               colName="authorities"
               isVisible={{ base: false, lg: true }}
             >
-              Authorities
+              {t('admin:authorities')}
             </DataListCell>
             <DataListCell
               colName="created"
               isVisible={{ base: false, lg: true }}
             >
-              Created by
+              {t('admin:createdBy')}
             </DataListCell>
             <DataListCell
               colName="lastModified"
               isVisible={{ base: false, md: true }}
             >
-              Modified by
+              {t('admin:modifiedBy')}
             </DataListCell>
             <DataListCell
               colName="status"
@@ -204,7 +207,7 @@ export const PageUsers = () => {
               align="center"
             >
               <Box as="span" d={{ base: 'none', md: 'block' }}>
-                Status
+                {t('admin:status')}
               </Box>
             </DataListCell>
             <DataListCell colName="actions" colWidth="4rem" align="flex-end" />

--- a/src/app/admin/users/UserStatus.tsx
+++ b/src/app/admin/users/UserStatus.tsx
@@ -7,22 +7,22 @@ export const UserStatus = ({ isActivated = false, ...rest }) => {
   return isActivated ? (
     <Badge size="sm" colorScheme="success" {...rest}>
       <Box as="span" d={{ base: 'none', md: 'block' }}>
-        {t('admin:activated')}
+        {t('admin:users.activated')}
       </Box>
       <Icon
         as={FiCheck}
-        aria-label={t('admin:activated')}
+        aria-label={t('admin:users.activated')}
         d={{ base: 'inline-flex', md: 'none' }}
       />
     </Badge>
   ) : (
     <Badge size="sm" colorScheme="warning" {...rest}>
       <Box as="span" d={{ base: 'none', md: 'block' }}>
-        {t('admin:notActivated')}
+        {t('admin:users.notActivated')}
       </Box>
       <Icon
         as={FiX}
-        aria-label={t('admin:notActivated')}
+        aria-label={t('admin:users.notActivated')}
         d={{ base: 'inline-flex', md: 'none' }}
       />
     </Badge>

--- a/src/app/admin/users/UserStatus.tsx
+++ b/src/app/admin/users/UserStatus.tsx
@@ -1,26 +1,28 @@
 import { Badge, Box, Icon } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
 import { FiCheck, FiX } from 'react-icons/fi';
 
 export const UserStatus = ({ isActivated = false, ...rest }) => {
+  const { t } = useTranslation()
   return isActivated ? (
     <Badge size="sm" colorScheme="success" {...rest}>
       <Box as="span" d={{ base: 'none', md: 'block' }}>
-        Activated
+        {t('admin:activated')}
       </Box>
       <Icon
         as={FiCheck}
-        aria-label="Activated"
+        aria-label={t('admin:activated')}
         d={{ base: 'inline-flex', md: 'none' }}
       />
     </Badge>
   ) : (
     <Badge size="sm" colorScheme="warning" {...rest}>
       <Box as="span" d={{ base: 'none', md: 'block' }}>
-        Not Activated
+        {t('admin:notActivated')}
       </Box>
       <Icon
         as={FiX}
-        aria-label="Not Activated"
+        aria-label={t('admin:notActivated')}
         d={{ base: 'inline-flex', md: 'none' }}
       />
     </Badge>

--- a/src/app/auth/LoginForm.tsx
+++ b/src/app/auth/LoginForm.tsx
@@ -3,11 +3,14 @@ import React from 'react';
 import { Box, Button, Flex, Stack } from '@chakra-ui/react';
 import { Formiz, useForm } from '@formiz/core';
 import { Link as RouterLink } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 import { useLogin } from '@/app/auth/service';
 import { FieldInput, useToastError } from '@/components';
 
-export const LoginForm = ({ onSuccess = () => {}, ...rest }) => {
+export const LoginForm = ({ onSuccess = () => { }, ...rest }) => {
+  const { t } = useTranslation();
+
   const form = useForm({ subscribe: 'form' });
   const toastError = useToastError();
 
@@ -15,7 +18,7 @@ export const LoginForm = ({ onSuccess = () => {}, ...rest }) => {
     onSuccess,
     onError: (error: any) => {
       toastError({
-        title: 'Login failed',
+        title: t('form.messages.loginFailed'),
         description: error?.response?.data?.title,
       });
     },
@@ -27,14 +30,14 @@ export const LoginForm = ({ onSuccess = () => {}, ...rest }) => {
         <Stack spacing="4">
           <FieldInput
             name="username"
-            label="Username"
-            required="Username is required"
+            label={t('auth:form.username.label')}
+            required={t('auth:form.username.required') as string}
           />
           <FieldInput
             name="password"
             type="password"
-            label="Password"
-            required="Password is required"
+            label={t('auth:form.password.label')}
+            required={t('auth:form.password.required') as string}
           />
           <Flex>
             <Button
@@ -43,7 +46,7 @@ export const LoginForm = ({ onSuccess = () => {}, ...rest }) => {
               size="sm"
               variant="link"
             >
-              Forgot password?
+              {t('auth:forgotPassword')}
             </Button>
             <Button
               isLoading={isLoading}
@@ -52,7 +55,7 @@ export const LoginForm = ({ onSuccess = () => {}, ...rest }) => {
               colorScheme="brand"
               ml="auto"
             >
-              Log In
+              {t('auth:login')}
             </Button>
           </Flex>
         </Stack>

--- a/src/app/auth/LoginForm.tsx
+++ b/src/app/auth/LoginForm.tsx
@@ -18,7 +18,7 @@ export const LoginForm = ({ onSuccess = () => { }, ...rest }) => {
     onSuccess,
     onError: (error: any) => {
       toastError({
-        title: t('form.messages.loginFailed'),
+        title: t('auth:messages.loginFailed'),
         description: error?.response?.data?.title,
       });
     },

--- a/src/app/auth/LoginModalInterceptor.tsx
+++ b/src/app/auth/LoginModalInterceptor.tsx
@@ -13,11 +13,13 @@ import {
 import Axios from 'axios';
 import { useQueryClient } from 'react-query';
 import { useLocation, useHistory } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 import { useAuthContext } from '@/app/auth/AuthContext';
 import { LoginForm } from '@/app/auth/LoginForm';
 
 export const LoginModalInterceptor = () => {
+  const { t } = useTranslation();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { isLogged, updateToken } = useAuthContext();
   const queryCache = useQueryClient();
@@ -75,8 +77,8 @@ export const LoginModalInterceptor = () => {
       <ModalContent>
         <ModalCloseButton />
         <ModalBody p="6">
-          <Heading size="lg">Login needed</Heading>
-          <Text mb="2">Please, login to continue</Text>
+          <Heading size="lg">{t('auth:loginNeeded')}</Heading>
+          <Text mb="2">{t('auth:pleaseLoginToContinue')}</Text>
           <LoginForm onSuccess={handleLogin} />
         </ModalBody>
       </ModalContent>

--- a/src/app/auth/PageLogin.tsx
+++ b/src/app/auth/PageLogin.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { Box, Button, Center, Heading } from '@chakra-ui/react';
 import { useQueryClient } from 'react-query';
 import { Link as RouterLink } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 import { LoginForm } from '@/app/auth/LoginForm';
 import { useRedirectFromUrl } from '@/app/router';
 
 export const PageLogin = () => {
+  const { t } = useTranslation();
   const redirect = useRedirectFromUrl();
   const queryCache = useQueryClient();
   const onLogin = () => {
@@ -16,13 +18,13 @@ export const PageLogin = () => {
   };
   return (
     <Box p="6" pb="4rem" w="20rem" maxW="full" m="auto">
-      <Heading my="4">Log In</Heading>
+      <Heading my="4">{t('auth:login')}</Heading>
       <LoginForm onSuccess={onLogin} />
       <Center mt="8">
         <Button as={RouterLink} to="/account/register" variant="link">
-          Need an account?{' '}
+          {t('auth:needAccount')}{' '}
           <Box as="strong" color="brand.500" ml="2">
-            Register now!
+            {t('auth:register')}
           </Box>
         </Button>
       </Center>

--- a/src/app/dashboard/PageDashboard.tsx
+++ b/src/app/dashboard/PageDashboard.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import { Heading } from '@chakra-ui/react';
 
 import { Page, PageHeader, PageBody, PageFooter } from '@/components';
+import { useTranslation } from 'react-i18next';
 
 export const PageDashboard = () => {
+  const { t } = useTranslation()
   return (
     <Page>
       <PageHeader>
-        <Heading size="md">Dashboard</Heading>
+        <Heading size="md">{t('dashboard:title')}</Heading>
       </PageHeader>
       <PageBody>Body</PageBody>
       <PageFooter>Footer</PageFooter>

--- a/src/app/layout/Navbar.tsx
+++ b/src/app/layout/Navbar.tsx
@@ -76,12 +76,15 @@ const NavbarItem = ({ to, ...rest }: any) => {
   );
 };
 
-const NavbarMenu = (props) => (
-  <Stack direction="row" spacing="1" {...props}>
-    <NavbarItem to="/dashboard">Dashboard</NavbarItem>
-    <NavbarItem to="/entity">Entity</NavbarItem>
-  </Stack>
-);
+const NavbarMenu = (props) => {
+  const { t } = useTranslation();
+  return (
+    <Stack direction="row" spacing="1" {...props}>
+      <NavbarItem to="/dashboard">{t('dashboard:title')}</NavbarItem>
+      <NavbarItem to="/entity">{t('entities:title')}</NavbarItem>
+    </Stack>
+  );
+}
 
 const NavbarMenuButton = (props) => {
   const { onOpen } = useContext(NavbarContext);
@@ -159,7 +162,7 @@ const NavbarAccountMenu = (props) => {
           icon={<Icon as={FiLogOut} fontSize="lg" color="gray.400" />}
           onClick={() => history.push('/logout')}
         >
-          Logout
+          {t('layout:navbar.logout')}
         </MenuItem>
       </MenuList>
     </Menu>

--- a/src/app/layout/Navbar.tsx
+++ b/src/app/layout/Navbar.tsx
@@ -149,7 +149,7 @@ const NavbarAccountMenu = (props) => {
                 icon={<Icon as={FiUsers} fontSize="lg" color="gray.400" />}
                 onClick={() => history.push('/admin/users')}
               >
-                User Management
+                {t('layout:navbar.userManagement')}
               </MenuItem>
             </MenuGroup>
             <MenuDivider />

--- a/src/app/layout/Navbar.tsx
+++ b/src/app/layout/Navbar.tsx
@@ -27,6 +27,7 @@ import {
 } from '@chakra-ui/react';
 import { FiLogOut, FiMenu, FiUser, FiUsers } from 'react-icons/fi';
 import { Link as RouterLink, useLocation, useHistory } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 import { useAccount } from '@/app/account/service';
 
@@ -120,6 +121,7 @@ const NavbarMenuDrawer = ({ children, ...rest }) => {
 };
 
 const NavbarAccountMenu = (props) => {
+  const { t } = useTranslation();
   const { account, isAdmin, isLoading } = useAccount();
   const history = useHistory();
 
@@ -136,7 +138,7 @@ const NavbarAccountMenu = (props) => {
             icon={<Icon as={FiUser} fontSize="lg" color="gray.400" />}
             onClick={() => history.push('/account')}
           >
-            My Account
+            {t('layout:navbar.myAccount')}
           </MenuItem>
         </MenuGroup>
         <MenuDivider />

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -1,0 +1,22 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import httpBackend from 'i18next-http-backend';
+
+
+i18n
+  .use(httpBackend)
+  .use(initReactI18next) // passes i18n down to react-i18next
+  .init({
+    backend: {
+      loadPath: '/locales/{{lng}}/{{ns}}.json',
+    },
+    lng: "en",
+
+    keySeparator: false, // we do not use keys in form messages.welcome
+
+    interpolation: {
+      escapeValue: false // react already safes from xss
+    }
+  });
+
+  export default i18n;

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -1,22 +1,28 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import httpBackend from 'i18next-http-backend';
+import enTranslations from '@/i18n/en';
+import frTranslations from '@/i18n/fr';
 
+const translations = {
+  en: enTranslations,
+  fr: frTranslations,
+}
 
 i18n
-  .use(httpBackend)
-  .use(initReactI18next) // passes i18n down to react-i18next
+  // .use(httpBackend)
+  .use(initReactI18next)
   .init({
     backend: {
       loadPath: '/locales/{{lng}}/{{ns}}.json',
     },
     lng: "en",
+    resources: translations,
 
     keySeparator: false, // we do not use keys in form messages.welcome
 
     interpolation: {
       escapeValue: false // react already safes from xss
-    }
+    },
   });
 
-  export default i18n;
+export default i18n;

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -1,24 +1,23 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import enTranslations from '@/i18n/en';
-import frTranslations from '@/i18n/fr';
+import LanguageDetector from 'i18next-browser-languagedetector';
 
-const translations = {
-  en: enTranslations,
-  fr: frTranslations,
-}
+import en from '@/i18n/en';
+import fr from '@/i18n/fr';
+
+export const resources = {
+  en,
+  fr,
+} as const;
 
 i18n
-  // .use(httpBackend)
   .use(initReactI18next)
+  .use(LanguageDetector)
   .init({
-    backend: {
-      loadPath: '/locales/{{lng}}/{{ns}}.json',
-    },
-    lng: "en",
-    resources: translations,
-
-    keySeparator: false, // we do not use keys in form messages.welcome
+    ns: Object.keys(resources.en),
+    defaultNS: 'common',
+    resources,
+    fallbackLng: 'en',
 
     interpolation: {
       escapeValue: false // react already safes from xss

--- a/src/i18n/en/account.ts
+++ b/src/i18n/en/account.ts
@@ -1,0 +1,49 @@
+export const account = {
+  title: 'Account',
+  accountActivation: {
+    accountActivationPending: 'Account Activation...',
+    accountActivationSuccess: 'Account Activation Success',
+    accountActivationError: 'Account Activation Failed',
+  },
+  register: {
+    title: 'Register',
+    form: {
+      login: {
+        label: 'Username',
+        userexists: 'Login already used',
+        required: 'Username is required',
+        isMinLength: 'Username too short (min. {{count}} characters)',
+        isMaxLength: 'Username too long (max. {{count}} characters)',
+        isPattern: "Username is invalid, don't use special characters",
+      },
+      email: {
+        label: 'Email',
+        emailexists: 'Email already used',
+        required: 'Email is required',
+        isMinLength: 'Email too short (min. {{count}} characters)',
+        isMaxLength: 'Email too long (max. {{max}} characters)',
+        isEmail: 'Email is invalid',
+      },
+      password: {
+        label: 'Password',
+        required: 'Password is required',
+        isMinLength: 'Password too short (min. {{count}} characters)',
+        isMaxLength: 'Password too long (max. {{max}} characters)',
+      },
+    },
+    messages: {
+      registrationFailed: 'Registration Failed',
+      accountCreatedSuccess: {
+        title: 'Account created with success!',
+        description:
+          'Please check your email <1>{{accountEmail}}</1> inbox to activate your account.',
+      },
+    },
+    actions: {
+      goToLogin: 'Go to Login',
+      createAccount: 'Create Account',
+      alreadyHaveAnAccount: 'Already have an account?',
+      login: 'Login',
+    },
+  },
+};

--- a/src/i18n/en/admin.ts
+++ b/src/i18n/en/admin.ts
@@ -1,37 +1,39 @@
 export const admin = {
-  user: 'User',
-  userManagement: 'User Management',
-  loginEmail: 'Login / Email',
-  id: 'ID',
-  authorities: 'Authorities',
-  createdBy: 'Created By',
-  modifiedBy: 'Modified By',
-  status: 'Status',
-  activated: 'Activated',
-  notActivated: 'Not Activated',
-  messages: {
-    accountActivated: {
-      title: 'Account Activated',
-      description: 'Account "{{login}}" activated with success'
+  users: {
+    user: 'User',
+    userManagement: 'User Management',
+    loginEmail: 'Login / Email',
+    id: 'ID',
+    authorities: 'Authorities',
+    createdBy: 'Created By',
+    modifiedBy: 'Modified By',
+    status: 'Status',
+    activated: 'Activated',
+    notActivated: 'Not Activated',
+    messages: {
+      accountActivated: {
+        title: 'Account Activated',
+        description: 'Account "{{login}}" activated with success'
+      },
+      accountDeactivated: {
+        title: 'Account Deactivated',
+        description: 'Account "{{login}}" deactivated with success'
+      },
+      accountActivationFailed: {
+        title: 'Activation Failed',
+        description: 'Fail to activate "{{login}}" account'
+      },
+      accountDeactivationFailed: {
+        title: 'Deactivation Failed',
+        description: 'Fail to deactivate "{{login}}" account'
+      }
     },
-    accountDeactivated: {
-      title: 'Account Deactivated',
-      description: 'Account "{{login}}" deactivated with success'
-    },
-    accountActivationFailed: {
-      title: 'Activation Failed',
-      description: 'Fail to activate "{{login}}" account'
-    },
-    accountDeactivationFailed: {
-      title: 'Deactivation Failed',
-      description: 'Fail to deactivate "{{login}}" account'
+    actions: {
+      edit: 'Edit',
+      deactivateAccount: 'Deactivate Account',
+      activateAccount: 'Activate Account',
+      delete: 'Delete',
+      createUser: 'Create User',
     }
-  },
-  actions: {
-    edit: 'Edit',
-    deactivateAccount: 'Deactivate Account',
-    activateAccount: 'Activate Account',
-    delete: 'Delete',
-    createUser: 'Create User',
   }
 }

--- a/src/i18n/en/admin.ts
+++ b/src/i18n/en/admin.ts
@@ -1,0 +1,37 @@
+export const admin = {
+  user: 'User',
+  userManagement: 'User Management',
+  loginEmail: 'Login / Email',
+  id: 'ID',
+  authorities: 'Authorities',
+  createdBy: 'Created By',
+  modifiedBy: 'Modified By',
+  status: 'Status',
+  activated: 'Activated',
+  notActivated: 'Not Activated',
+  messages: {
+    accountActivated: {
+      title: 'Account Activated',
+      description: 'Account "{{login}}" activated with success'
+    },
+    accountDeactivated: {
+      title: 'Account Deactivated',
+      description: 'Account "{{login}}" deactivated with success'
+    },
+    accountActivationFailed: {
+      title: 'Activation Failed',
+      description: 'Fail to activate "{{login}}" account'
+    },
+    accountDeactivationFailed: {
+      title: 'Deactivation Failed',
+      description: 'Fail to deactivate "{{login}}" account'
+    }
+  },
+  actions: {
+    edit: 'Edit',
+    deactivateAccount: 'Deactivate Account',
+    activateAccount: 'Activate Account',
+    delete: 'Delete',
+    createUser: 'Create User',
+  }
+}

--- a/src/i18n/en/auth.ts
+++ b/src/i18n/en/auth.ts
@@ -1,0 +1,24 @@
+export const auth = {
+  login: 'Log In',
+  form: {
+    username: {
+      label: 'Username',
+      required: 'Username is required'
+    },
+    password: {
+      label: 'Password',
+      required: 'Password is required'
+    }
+  },
+  forgotPassword: 'Forgot password?',
+  needAccount: 'Need account?',
+  register: 'Register now!',
+  actions: {
+    login: 'Log In'
+  },
+  messages: {
+    loginFailed: 'Login failed',
+    loginNeeded: 'Login needed',
+    pleaseLoginToContinue: 'Please log in to continue'
+  }
+}

--- a/src/i18n/en/common.ts
+++ b/src/i18n/en/common.ts
@@ -1,0 +1,5 @@
+const common = {
+  appTitle: 'Start UI (EN)',
+}
+
+export default common;

--- a/src/i18n/en/common.ts
+++ b/src/i18n/en/common.ts
@@ -1,5 +1,3 @@
-const common = {
+export const common = {
   appTitle: 'Start UI (EN)',
 }
-
-export default common;

--- a/src/i18n/en/dashboard.ts
+++ b/src/i18n/en/dashboard.ts
@@ -1,0 +1,3 @@
+export const dashboard = {
+  title: 'Dashboard',
+}

--- a/src/i18n/en/entities.ts
+++ b/src/i18n/en/entities.ts
@@ -1,0 +1,3 @@
+export const entities = {
+  title: 'Entities'
+}

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -2,11 +2,13 @@ import { common } from './common';
 import { auth } from './auth';
 import { layout } from './layout';
 import { admin } from './admin';
+import { dashboard } from './dashboard';
 
 const enTranslations = {
   auth,
   admin,
   common,
+  dashboard,
   layout,
 };
 

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -4,8 +4,10 @@ import { layout } from './layout';
 import { admin } from './admin';
 import { dashboard } from './dashboard';
 import { entities } from './entities';
+import { account } from './account';
 
 const enTranslations = {
+  account,
   auth,
   admin,
   common,

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -1,0 +1,7 @@
+import common from './common';
+
+const enTranslations = {
+  common,
+};
+
+export default enTranslations;

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -3,12 +3,14 @@ import { auth } from './auth';
 import { layout } from './layout';
 import { admin } from './admin';
 import { dashboard } from './dashboard';
+import { entities } from './entities';
 
 const enTranslations = {
   auth,
   admin,
   common,
   dashboard,
+  entities,
   layout,
 };
 

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -1,9 +1,11 @@
 import { common } from './common';
 import { auth } from './auth';
 import { layout } from './layout';
+import { admin } from './admin';
 
 const enTranslations = {
   auth,
+  admin,
   common,
   layout,
 };

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -1,7 +1,11 @@
-import common from './common';
+import { common } from './common';
+import { auth } from './auth';
+import { layout } from './layout';
 
 const enTranslations = {
+  auth,
   common,
+  layout,
 };
 
 export default enTranslations;

--- a/src/i18n/en/layout.ts
+++ b/src/i18n/en/layout.ts
@@ -1,0 +1,5 @@
+export const layout = {
+  navbar: {
+    myAccount: 'My Account',
+  }
+}

--- a/src/i18n/en/layout.ts
+++ b/src/i18n/en/layout.ts
@@ -1,6 +1,7 @@
 export const layout = {
   navbar: {
     myAccount: 'My Account',
-    userManagement: 'User management'
+    userManagement: 'User management',
+    logout: 'Logout',
   }
 }

--- a/src/i18n/en/layout.ts
+++ b/src/i18n/en/layout.ts
@@ -1,5 +1,6 @@
 export const layout = {
   navbar: {
     myAccount: 'My Account',
+    userManagement: 'User management'
   }
 }

--- a/src/i18n/fr/account.ts
+++ b/src/i18n/fr/account.ts
@@ -1,0 +1,53 @@
+export const account = {
+  title: 'Compte',
+  accountActivation: {
+    accountActivationPending: 'Activation du compte...',
+    accountActivationSuccess: 'Compte activé avec succès',
+    accountActivationError:
+      "Un problème est survenu lors de l'actication du compte",
+  },
+  register: {
+    title: 'Inscription',
+    form: {
+      login: {
+        label: 'Identifiant',
+        userexists: 'Identifiant déjà utilisé',
+        required: "L'identifiant est requis",
+        isMinLength: "L'identifiant est trop petit ({{count}} caractères min.)",
+        isMaxLength: "L'identifiant est trop long ({{count}} caractères max.)",
+        isPattern:
+          "L'identifiant est invalide, n'utilisez pas de caractères spéciaux",
+      },
+      email: {
+        label: 'Email',
+        emailexists: 'Email déjà utilisé',
+        required: "L'email est requis",
+        isMinLength: "L'email est trop petit ({{count}} caractères min.)",
+        isMaxLength: "L'email est trop long ({{count}} caractères max.)",
+        isEmail: "L'email est invalide",
+      },
+      password: {
+        label: 'Mot de passe',
+        required: 'Le mot de passe est requis',
+        isMinLength:
+          'Le mot de passe est trop petit ({{count}} caractères min.)',
+        isMaxLength:
+          'Le mot de passe est trop long ({{count}} caractères max.)',
+      },
+    },
+    messages: {
+      registrationFailed: "L'inscription a échoué",
+      accountCreatedSuccess: {
+        title: 'Compte créé avec succès !',
+        description:
+          'Veuillez valider votre email <1>{{accountEmail}}</1> dans votre messagerie pour activer votre compte.',
+      },
+    },
+    actions: {
+      goToLogin: 'Me connecter',
+      createAccount: 'Créer le compte',
+      alreadyHaveAnAccount: "Déjà un compte ?",
+      login: "Connexion",
+    },
+  },
+};

--- a/src/i18n/fr/admin.ts
+++ b/src/i18n/fr/admin.ts
@@ -1,0 +1,37 @@
+export const admin = {
+  user: 'Utilisateur',
+  userManagement: 'Gestion des utilisateurs',
+  loginEmail: 'Login / Email',
+  id: 'ID',
+  authorities: 'Droits',
+  createdBy: 'Créé Par',
+  modifiedBy: 'Modifié Par',
+  status: 'Status',
+  activated: 'Activé',
+  notActivated: 'Désactivé',
+  messages: {
+    accountActivated: {
+      title: 'Compte Activé',
+      description: 'Compte "{{login}}" activé avec succès'
+    },
+    accountDeactivated: {
+      title: 'Compte Désactivé',
+      description: 'Compte "{{login}}" désactivé avec succès'
+    },
+    accountActivationFailed: {
+      title: 'Echec Activation',
+      description: 'Le compte "{{login}}" n\'a pas pu être activé',
+    },
+    accountDeactivationFailed: {
+      title: 'Echec Désactivation',
+      description: 'Le compte "{{login}}" n\'a pas pu être désactivé'
+    }
+  },
+  actions: {
+    edit: 'Modifier',
+    deactivateAccount: 'Désactiver le compte',
+    activateAccount: 'Activer le compte',
+    delete: 'Supprimer',
+    createUser: 'Créer un utilisateur'
+  }
+}

--- a/src/i18n/fr/admin.ts
+++ b/src/i18n/fr/admin.ts
@@ -1,37 +1,39 @@
 export const admin = {
-  user: 'Utilisateur',
-  userManagement: 'Gestion des utilisateurs',
-  loginEmail: 'Login / Email',
-  id: 'ID',
-  authorities: 'Droits',
-  createdBy: 'Créé Par',
-  modifiedBy: 'Modifié Par',
-  status: 'Status',
-  activated: 'Activé',
-  notActivated: 'Désactivé',
-  messages: {
-    accountActivated: {
-      title: 'Compte Activé',
-      description: 'Compte "{{login}}" activé avec succès'
+  users: {
+    user: 'Utilisateur',
+    userManagement: 'Gestion des utilisateurs',
+    loginEmail: 'Login / Email',
+    id: 'ID',
+    authorities: 'Droits',
+    createdBy: 'Créé Par',
+    modifiedBy: 'Modifié Par',
+    status: 'Status',
+    activated: 'Activé',
+    notActivated: 'Désactivé',
+    messages: {
+      accountActivated: {
+        title: 'Compte Activé',
+        description: 'Compte "{{login}}" activé avec succès'
+      },
+      accountDeactivated: {
+        title: 'Compte Désactivé',
+        description: 'Compte "{{login}}" désactivé avec succès'
+      },
+      accountActivationFailed: {
+        title: 'Echec Activation',
+        description: 'Le compte "{{login}}" n\'a pas pu être activé',
+      },
+      accountDeactivationFailed: {
+        title: 'Echec Désactivation',
+        description: 'Le compte "{{login}}" n\'a pas pu être désactivé'
+      }
     },
-    accountDeactivated: {
-      title: 'Compte Désactivé',
-      description: 'Compte "{{login}}" désactivé avec succès'
-    },
-    accountActivationFailed: {
-      title: 'Echec Activation',
-      description: 'Le compte "{{login}}" n\'a pas pu être activé',
-    },
-    accountDeactivationFailed: {
-      title: 'Echec Désactivation',
-      description: 'Le compte "{{login}}" n\'a pas pu être désactivé'
+    actions: {
+      edit: 'Modifier',
+      deactivateAccount: 'Désactiver le compte',
+      activateAccount: 'Activer le compte',
+      delete: 'Supprimer',
+      createUser: 'Créer un utilisateur'
     }
-  },
-  actions: {
-    edit: 'Modifier',
-    deactivateAccount: 'Désactiver le compte',
-    activateAccount: 'Activer le compte',
-    delete: 'Supprimer',
-    createUser: 'Créer un utilisateur'
   }
 }

--- a/src/i18n/fr/auth.ts
+++ b/src/i18n/fr/auth.ts
@@ -17,7 +17,7 @@ export const auth = {
     login: 'Connexion'
   },
   messages: {
-    loginFailed: 'La connexion a échouée',
+    loginFailed: 'La connexion a échoué',
     loginNeeded: 'Connexion requise',
     pleaseLoginToContinue: 'Connectez vous pour continuer'
   }

--- a/src/i18n/fr/auth.ts
+++ b/src/i18n/fr/auth.ts
@@ -1,0 +1,24 @@
+export const auth = {
+  login: 'Connexion',
+  form: {
+    username: {
+      label: 'Identifiant',
+      required: 'L\'identifiant est requis'
+    },
+    password: {
+      label: 'Mot de passe',
+      required: 'Le mot de passe est requis'
+    }
+  },
+  forgotPassword: 'Mot de passe oublié ?',
+  needAccount: 'Besoin d\'un compte ?',
+  register: 'M\'enregistrer !',
+  actions: {
+    login: 'Connexion'
+  },
+  messages: {
+    loginFailed: 'La connexion a échouée',
+    loginNeeded: 'Connexion requise',
+    pleaseLoginToContinue: 'Connectez vous pour continuer'
+  }
+}

--- a/src/i18n/fr/common.ts
+++ b/src/i18n/fr/common.ts
@@ -1,0 +1,5 @@
+const common = {
+  appTitle: 'Start UI (FR)',
+}
+
+export default common;

--- a/src/i18n/fr/common.ts
+++ b/src/i18n/fr/common.ts
@@ -1,5 +1,3 @@
-const common = {
+export const common = {
   appTitle: 'Start UI (FR)',
 }
-
-export default common;

--- a/src/i18n/fr/dashboard.ts
+++ b/src/i18n/fr/dashboard.ts
@@ -1,0 +1,3 @@
+export const dashboard = {
+  title: 'Dashboard',
+}

--- a/src/i18n/fr/entities.ts
+++ b/src/i18n/fr/entities.ts
@@ -1,0 +1,3 @@
+export const entities = {
+  title: 'Entités',
+};

--- a/src/i18n/fr/index.ts
+++ b/src/i18n/fr/index.ts
@@ -2,11 +2,13 @@ import { common } from './common';
 import { auth } from './auth';
 import { layout } from './layout';
 import { admin } from './admin';
+import { dashboard } from './dashboard';
 
 const enTranslations = {
   auth,
   admin,
   common,
+  dashboard,
   layout,
 };
 

--- a/src/i18n/fr/index.ts
+++ b/src/i18n/fr/index.ts
@@ -4,8 +4,10 @@ import { layout } from './layout';
 import { admin } from './admin';
 import { dashboard } from './dashboard';
 import { entities } from './entities';
+import { account } from './account';
 
 const enTranslations = {
+  account,
   auth,
   admin,
   common,

--- a/src/i18n/fr/index.ts
+++ b/src/i18n/fr/index.ts
@@ -1,0 +1,7 @@
+import common from './common';
+
+const enTranslations = {
+  common,
+};
+
+export default enTranslations;

--- a/src/i18n/fr/index.ts
+++ b/src/i18n/fr/index.ts
@@ -3,12 +3,14 @@ import { auth } from './auth';
 import { layout } from './layout';
 import { admin } from './admin';
 import { dashboard } from './dashboard';
+import { entities } from './entities';
 
 const enTranslations = {
   auth,
   admin,
   common,
   dashboard,
+  entities,
   layout,
 };
 

--- a/src/i18n/fr/index.ts
+++ b/src/i18n/fr/index.ts
@@ -1,9 +1,11 @@
 import { common } from './common';
 import { auth } from './auth';
 import { layout } from './layout';
+import { admin } from './admin';
 
 const enTranslations = {
   auth,
+  admin,
   common,
   layout,
 };

--- a/src/i18n/fr/index.ts
+++ b/src/i18n/fr/index.ts
@@ -1,7 +1,11 @@
-import common from './common';
+import { common } from './common';
+import { auth } from './auth';
+import { layout } from './layout';
 
 const enTranslations = {
+  auth,
   common,
+  layout,
 };
 
 export default enTranslations;

--- a/src/i18n/fr/layout.ts
+++ b/src/i18n/fr/layout.ts
@@ -1,6 +1,7 @@
 export const layout = {
   navbar: {
     myAccount: 'Mon compte',
-    userManagement: 'Gestion des utilisateurs'
-  }
-}
+    userManagement: 'Gestion des utilisateurs',
+    logout: 'Déconnexion',
+  },
+};

--- a/src/i18n/fr/layout.ts
+++ b/src/i18n/fr/layout.ts
@@ -1,5 +1,6 @@
 export const layout = {
   navbar: {
     myAccount: 'Mon compte',
+    userManagement: 'Gestion des utilisateurs'
   }
 }

--- a/src/i18n/fr/layout.ts
+++ b/src/i18n/fr/layout.ts
@@ -1,0 +1,5 @@
+export const layout = {
+  navbar: {
+    myAccount: 'Mon compte',
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ import { isBrowser } from '@/utils/ssr';
 import { useTranslation } from 'react-i18next';
 
 const Index = () => {
-  const { t } = useTranslation('common');
+  const { t } = useTranslation();
   return (
     <>
       <Head>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-
 import Head from 'next/head';
 
 import { App } from '@/app/App';
 import { isBrowser } from '@/utils/ssr';
+import { useTranslation } from 'react-i18next';
 
 const Index = () => {
+  // const { t } = useTranslation();
   return (
     <>
       <Head>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,11 +6,11 @@ import { isBrowser } from '@/utils/ssr';
 import { useTranslation } from 'react-i18next';
 
 const Index = () => {
-  // const { t } = useTranslation();
+  const { t } = useTranslation('common');
   return (
     <>
       <Head>
-        <title>Start UI</title>
+        <title>{t('appTitle')}</title>
       </Head>
       <div suppressHydrationWarning={true}>{isBrowser && <App />}</div>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7900,6 +7900,13 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
+html-parse-stringify2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz#dc5670b7292ca158b7bc916c9a6735ac8872834a"
+  integrity sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=
+  dependencies:
+    void-elements "^2.0.1"
+
 html-tags@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
@@ -8011,6 +8018,20 @@ husky@4.3.6:
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
+
+i18next-http-backend@1.0.21:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/i18next-http-backend/-/i18next-http-backend-1.0.21.tgz#cee901b3527dad5165fa91de973b6aa6404c1c37"
+  integrity sha512-UDeHoV2B+31Gr++0KFAVjM5l+SEwePpF6sfDyaDq5ennM9QNJ78PBEMPStwkreEm4h5C8sT7M1JdNQrLcU1Wdg==
+  dependencies:
+    node-fetch "2.6.1"
+
+i18next@19.8.4:
+  version "19.8.4"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.8.4.tgz#447718f2a26319b8debdbcc6fbc1a9761be7316b"
+  integrity sha512-FfVPNWv+felJObeZ6DSXZkj9QM1Ivvh7NcFCgA8XPtJWHz0iXVa9BUy+QY8EPrCLE+vWgDfV/sc96BgXVo6HAA==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -11425,6 +11446,14 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-i18next@11.8.3:
+  version "11.8.3"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.8.3.tgz#d365586a537f759a1bff75e01054f6a5fc71e4f5"
+  integrity sha512-E5LjGmM3Kgje4M0oSkHFNAxiU1BM+P1J9QPfF7+Agm4sa1YS18GhQNJCZD3o9ofZLjq8ocQfGUuYweYGfrj0RQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    html-parse-stringify2 "2.0.1"
+
 react-icons@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.1.0.tgz#9ca9bcbf2e3aee8e86e378bb9d465842947bbfc3"
@@ -13790,6 +13819,11 @@ vm-browserify@1.1.2, vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+void-elements@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
+  integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8019,6 +8019,13 @@ husky@4.3.6:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
+i18next-browser-languagedetector@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.0.1.tgz#83654bc87302be2a6a5a75146ffea97b4ca268cf"
+  integrity sha512-3H+OsNQn3FciomUU0d4zPFHsvJv4X66lBelXk9hnIDYDsveIgT7dWZ3/VvcSlpKk9lvCK770blRZ/CwHMXZqWw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+
 i18next-http-backend@1.0.21:
   version "1.0.21"
   resolved "https://registry.yarnpkg.com/i18next-http-backend/-/i18next-http-backend-1.0.21.tgz#cee901b3527dad5165fa91de973b6aa6404c1c37"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,7 +1143,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.12.5", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@7.12.5", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -11446,10 +11446,10 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
-react-i18next@11.8.3:
-  version "11.8.3"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.8.3.tgz#d365586a537f759a1bff75e01054f6a5fc71e4f5"
-  integrity sha512-E5LjGmM3Kgje4M0oSkHFNAxiU1BM+P1J9QPfF7+Agm4sa1YS18GhQNJCZD3o9ofZLjq8ocQfGUuYweYGfrj0RQ==
+react-i18next@11.8.4:
+  version "11.8.4"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.8.4.tgz#5407d2edcaa704c38e4034e7ac06413914ed6e6d"
+  integrity sha512-QlPJfX+Roi+jEQ6frBSsLHHH+VWbUoCl6wZDT8XHMd6PsSgepjgD2sZf/h7F46JnHeuy0U+SxY3TtrJF+aDIyg==
   dependencies:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"


### PR DESCRIPTION
See #4 for further informations

## i18n support for start-ui

⚠️ We will handle the language change and persistance inside another PR (jhipster store a `langKey` property on the user level) (https://github.com/BearStudio/start-ui/issues/8)

### Right now, the PR adds the following:

- Support for EN and FR translations
- Detect language based on system properties (thanks to i18next-browser-languagedetector) and persist it in the local-storage
- Translations added on all pages with content
- Basic file structure

Translations file and object structure is a subject opened to discussion :)

## How to test ?

You can try updating the language used by appending on any urls `?lng=fr` for fr, or `?lng=en` for en