### PR TITLE
Fix: Add mock in test for external css

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
   moduleNameMapper: {
     '@/(.*)': '<rootDir>/src/$1',
+    '\\.(css|less|scss|sass)$': '<rootDir>/src/__mocks__/styleMock.js',
   },
 };

--- a/src/__mocks__/styleMock.js
+++ b/src/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
Fix `App.spec.test`, mock css loading from external components  