### PR TITLE
fix: remove isLazy prop from Nav component

### DIFF
--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -35,7 +35,7 @@ export const Nav: ChakraComponent<'div', NavProps> = ({
   const [active, setActive] = useState(<>Navigation</>);
   return (
     <NavContext.Provider value={{ active, setActive }}>
-      <Menu isLazy matchWidth {...rest}>
+      <Menu matchWidth {...rest}>
         {!isMenu && <Stack spacing="1">{children}</Stack>}
         {isMenu && (
           <>


### PR DESCRIPTION
isLazy prop could have side effect (the active state on mobile can be
out of sync) if the page is not rerendered

closes #44