### PR TITLE
Implement sizes for Popover component

### DIFF
--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,5 +1,6 @@
 export { default as Badge } from './badge';
 export { default as Button } from './button';
 export { default as Input } from './input';
+export { default as Popover } from './popover';
 export { default as Select } from './select';
 export { default as Textarea } from './textarea';

--- a/src/theme/components/popover.ts
+++ b/src/theme/components/popover.ts
@@ -1,0 +1,77 @@
+export default {
+  sizes: {
+    '3xs': {
+      content: {
+        width: '3xs',
+      },
+    },
+    '2xs': {
+      content: {
+        width: '2xs',
+      },
+    },
+    xs: {
+      content: {
+        width: 'xs',
+      },
+    },
+    sm: {
+      content: {
+        width: 'sm',
+      },
+    },
+    md: {
+      content: {
+        width: 'md',
+      },
+    },
+    lg: {
+      content: {
+        width: 'lg',
+      },
+    },
+    xl: {
+      content: {
+        width: 'xl',
+      },
+    },
+    '2xl': {
+      content: {
+        width: '2xl',
+      },
+    },
+    '3xl': {
+      content: {
+        width: '3xl',
+      },
+    },
+    '4xl': {
+      content: {
+        width: '4xl',
+      },
+    },
+    '5xl': {
+      content: {
+        width: '5xl',
+      },
+    },
+    '6xl': {
+      content: {
+        width: '6xl',
+      },
+    },
+    '7xl': {
+      content: {
+        width: '7xl',
+      },
+    },
+    '8xl': {
+      content: {
+        width: '8xl',
+      },
+    },
+  },
+  defaultProps: {
+    size: 'xs',
+  },
+};


### PR DESCRIPTION
## Description

By default in Chakra-UI, only one size is implemented for the Popover component. The [documentation](https://chakra-ui.com/docs/overlay/popover#popover-props) says that it can be implemented in the custom theme.

This MR implements all sizes available in Chakra-UI right now from "3xs" to "8xl". It also keeps the default value of Chakra-UI (xs)